### PR TITLE
Jesus. Okay. Move to a homebuilt feed generator.

### DIFF
--- a/nitre/versions/95337e33ecd9_rename_columns_for_podcasts.py
+++ b/nitre/versions/95337e33ecd9_rename_columns_for_podcasts.py
@@ -1,0 +1,97 @@
+"""rename columns for podcasts
+
+Revision ID: 95337e33ecd9
+Revises: 7c4972557441
+Create Date: 2024-01-17 17:32:20.979125
+
+"""
+from datetime import datetime
+from typing import Literal, Optional, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Column, orm
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+# revision identifiers, used by Alembic.
+revision: str = '95337e33ecd9'
+down_revision: Union[str, None] = '7c4972557441'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+Base = orm.declarative_base()
+
+
+class Podcast(Base):
+    __tablename__ = 'podcast'
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    name: Mapped[str]
+    website: Mapped[str]
+    author_name: Mapped[str]
+    withhold_from_itunes: Mapped[bool] = mapped_column(default=False)
+
+    title: Mapped[str]
+    link: Mapped[str]
+    author: Mapped[str]
+    itunes_block: Mapped[bool] = mapped_column(default=False)
+
+    new_feed_url: Mapped[Optional[str]] = mapped_column(nullable=True)
+    complete: Mapped[bool] = mapped_column(default=False)
+
+
+class Episode(Base):
+    __tablename__ = 'episode'
+    id: Mapped[int] = mapped_column(primary_key=True)
+    summary: Mapped[Optional[str]]
+    long_summary: Mapped[Optional[str]]
+    episode_art: Mapped[Optional[str]]
+    last_modified: Mapped[Optional[datetime]]
+
+    description: Mapped[Optional[str]]
+    image: Mapped[Optional[str]]
+    last_build_date: Mapped[Optional[datetime]]
+
+    # explicit: Mapped[bool] = mapped_column(default=False)
+    episode_type: Mapped[Literal["full", "trailer", "bonus"]] = mapped_column(default='full')
+    season: Mapped[Optional[int]]
+    episode: Mapped[Optional[int]]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    Podcast.metadata.create_all(bind=bind)
+    op.alter_column('podcast', 'name', new_column_name='title')
+    op.alter_column('podcast', 'website', new_column_name='link')
+    op.alter_column('podcast', 'author_name', new_column_name='author')
+    op.alter_column('podcast', 'withhold_from_itunes', new_column_name='itunes_block')
+    op.alter_column('podcast', 'last_modified', new_column_name='last_build_date')
+
+    with op.batch_alter_table('podcast', recreate="always") as alter_podcats:
+        alter_podcats.add_column(Column('new_feed_url', sa.String(), nullable=True), insert_after='itunes_block')
+        alter_podcats.add_column(Column('complete', sa.Boolean(), default=False), insert_after='new_feed_url')
+
+    with op.batch_alter_table('episode', recreate='always') as batch_op:
+        batch_op.drop_constraint('title_summary_check')
+
+        batch_op.drop_column('summary')
+
+        batch_op.alter_column('title', nullable=False)
+        batch_op.alter_column('long_summary', new_column_name='description')
+        batch_op.alter_column('episode_art', new_column_name='image')
+
+        # batch_op.add_column(Column('explicit', sa.Boolean(), default=False))
+        batch_op.add_column(Column('episode_type', sa.String(length=7), nullable=True))
+        batch_op.add_column(Column('season', sa.Integer(), nullable=True))
+        batch_op.add_column(Column('episode', sa.Integer(), nullable=True))
+    # Episode.metadata.add_column(Episode.season)
+    # Episode.metadata.create_all(bind=bind)
+    # session.commit()
+    # op.drop_column('episode', 'summary')
+    session.commit()
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,17 +32,17 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.34.19"
+version = "1.34.21"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "boto3-1.34.19-py3-none-any.whl", hash = "sha256:4c76ef92af7dbdcea21b196a2699671e82e8814d4cfe570c48eda477dd1aeb19"},
-    {file = "boto3-1.34.19.tar.gz", hash = "sha256:95d2c2bde86a0934d4c461020c50fc1344b444f167654e215f1de549bc77fc0f"},
+    {file = "boto3-1.34.21-py3-none-any.whl", hash = "sha256:88e3baeb53ae421aabd44bb49ebdd7122b74b53b0f437b0f3e17141f6744574a"},
+    {file = "boto3-1.34.21.tar.gz", hash = "sha256:206e61ba1f8c830e5df0355606d178ad5bc970df12c4c318b021c71da410eb0c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.19,<1.35.0"
+botocore = ">=1.34.21,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -51,13 +51,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.19"
+version = "1.34.21"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.19-py3-none-any.whl", hash = "sha256:a4a39c7092960f5da2439efc5f6220730dab634aaff4c1444bbd1dfa43bc28cc"},
-    {file = "botocore-1.34.19.tar.gz", hash = "sha256:64352b2f05de5c6ab025c1d5232880c22775356dcc5a53d798a6f65db847e826"},
+    {file = "botocore-1.34.21-py3-none-any.whl", hash = "sha256:43274fd3f8e02573790ee76313607c60e3c15a7a0d89d24dfe4042f882f1f8c9"},
+    {file = "botocore-1.34.21.tar.gz", hash = "sha256:21983bb0473a19130192c50ec6974d55f0c4aa48a7094bcf40f7882c8b69b8f1"},
 ]
 
 [package.dependencies]
@@ -224,20 +224,6 @@ files = [
     {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
     {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
 ]
-
-[[package]]
-name = "feedgen"
-version = "1.0.0"
-description = "Feed Generator (ATOM, RSS, Podcasts)"
-optional = false
-python-versions = "*"
-files = [
-    {file = "feedgen-1.0.0.tar.gz", hash = "sha256:d9bd51c3b5e956a2a52998c3708c4d2c729f2fcc311188e1e5d3b9726393546a"},
-]
-
-[package.dependencies]
-lxml = "*"
-python-dateutil = "*"
 
 [[package]]
 name = "filelock"
@@ -426,95 +412,6 @@ files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
-
-[[package]]
-name = "lxml"
-version = "5.1.0"
-description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "lxml-5.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d3c0f8567ffe7502d969c2c1b809892dc793b5d0665f602aad19895f8d508da"},
-    {file = "lxml-5.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5fcfbebdb0c5d8d18b84118842f31965d59ee3e66996ac842e21f957eb76138c"},
-    {file = "lxml-5.1.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f37c6d7106a9d6f0708d4e164b707037b7380fcd0b04c5bd9cae1fb46a856fb"},
-    {file = "lxml-5.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2befa20a13f1a75c751f47e00929fb3433d67eb9923c2c0b364de449121f447c"},
-    {file = "lxml-5.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22b7ee4c35f374e2c20337a95502057964d7e35b996b1c667b5c65c567d2252a"},
-    {file = "lxml-5.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bf8443781533b8d37b295016a4b53c1494fa9a03573c09ca5104550c138d5c05"},
-    {file = "lxml-5.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:82bddf0e72cb2af3cbba7cec1d2fd11fda0de6be8f4492223d4a268713ef2147"},
-    {file = "lxml-5.1.0-cp310-cp310-win32.whl", hash = "sha256:b66aa6357b265670bb574f050ffceefb98549c721cf28351b748be1ef9577d93"},
-    {file = "lxml-5.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:4946e7f59b7b6a9e27bef34422f645e9a368cb2be11bf1ef3cafc39a1f6ba68d"},
-    {file = "lxml-5.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ed8c3d2cd329bf779b7ed38db176738f3f8be637bb395ce9629fc76f78afe3d4"},
-    {file = "lxml-5.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:436a943c2900bb98123b06437cdd30580a61340fbdb7b28aaf345a459c19046a"},
-    {file = "lxml-5.1.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:acb6b2f96f60f70e7f34efe0c3ea34ca63f19ca63ce90019c6cbca6b676e81fa"},
-    {file = "lxml-5.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af8920ce4a55ff41167ddbc20077f5698c2e710ad3353d32a07d3264f3a2021e"},
-    {file = "lxml-5.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cfced4a069003d8913408e10ca8ed092c49a7f6cefee9bb74b6b3e860683b45"},
-    {file = "lxml-5.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9e5ac3437746189a9b4121db2a7b86056ac8786b12e88838696899328fc44bb2"},
-    {file = "lxml-5.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f4c9bda132ad108b387c33fabfea47866af87f4ea6ffb79418004f0521e63204"},
-    {file = "lxml-5.1.0-cp311-cp311-win32.whl", hash = "sha256:bc64d1b1dab08f679fb89c368f4c05693f58a9faf744c4d390d7ed1d8223869b"},
-    {file = "lxml-5.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:a5ab722ae5a873d8dcee1f5f45ddd93c34210aed44ff2dc643b5025981908cda"},
-    {file = "lxml-5.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6f11b77ec0979f7e4dc5ae081325a2946f1fe424148d3945f943ceaede98adb8"},
-    {file = "lxml-5.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a36c506e5f8aeb40680491d39ed94670487ce6614b9d27cabe45d94cd5d63e1e"},
-    {file = "lxml-5.1.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f643ffd2669ffd4b5a3e9b41c909b72b2a1d5e4915da90a77e119b8d48ce867a"},
-    {file = "lxml-5.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16dd953fb719f0ffc5bc067428fc9e88f599e15723a85618c45847c96f11f431"},
-    {file = "lxml-5.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16018f7099245157564d7148165132c70adb272fb5a17c048ba70d9cc542a1a1"},
-    {file = "lxml-5.1.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:82cd34f1081ae4ea2ede3d52f71b7be313756e99b4b5f829f89b12da552d3aa3"},
-    {file = "lxml-5.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:19a1bc898ae9f06bccb7c3e1dfd73897ecbbd2c96afe9095a6026016e5ca97b8"},
-    {file = "lxml-5.1.0-cp312-cp312-win32.whl", hash = "sha256:13521a321a25c641b9ea127ef478b580b5ec82aa2e9fc076c86169d161798b01"},
-    {file = "lxml-5.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:1ad17c20e3666c035db502c78b86e58ff6b5991906e55bdbef94977700c72623"},
-    {file = "lxml-5.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:24ef5a4631c0b6cceaf2dbca21687e29725b7c4e171f33a8f8ce23c12558ded1"},
-    {file = "lxml-5.1.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d2900b7f5318bc7ad8631d3d40190b95ef2aa8cc59473b73b294e4a55e9f30f"},
-    {file = "lxml-5.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:601f4a75797d7a770daed8b42b97cd1bb1ba18bd51a9382077a6a247a12aa38d"},
-    {file = "lxml-5.1.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4b68c961b5cc402cbd99cca5eb2547e46ce77260eb705f4d117fd9c3f932b95"},
-    {file = "lxml-5.1.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:afd825e30f8d1f521713a5669b63657bcfe5980a916c95855060048b88e1adb7"},
-    {file = "lxml-5.1.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:262bc5f512a66b527d026518507e78c2f9c2bd9eb5c8aeeb9f0eb43fcb69dc67"},
-    {file = "lxml-5.1.0-cp36-cp36m-win32.whl", hash = "sha256:e856c1c7255c739434489ec9c8aa9cdf5179785d10ff20add308b5d673bed5cd"},
-    {file = "lxml-5.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:c7257171bb8d4432fe9d6fdde4d55fdbe663a63636a17f7f9aaba9bcb3153ad7"},
-    {file = "lxml-5.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b9e240ae0ba96477682aa87899d94ddec1cc7926f9df29b1dd57b39e797d5ab5"},
-    {file = "lxml-5.1.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a96f02ba1bcd330807fc060ed91d1f7a20853da6dd449e5da4b09bfcc08fdcf5"},
-    {file = "lxml-5.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e3898ae2b58eeafedfe99e542a17859017d72d7f6a63de0f04f99c2cb125936"},
-    {file = "lxml-5.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61c5a7edbd7c695e54fca029ceb351fc45cd8860119a0f83e48be44e1c464862"},
-    {file = "lxml-5.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3aeca824b38ca78d9ee2ab82bd9883083d0492d9d17df065ba3b94e88e4d7ee6"},
-    {file = "lxml-5.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8f52fe6859b9db71ee609b0c0a70fea5f1e71c3462ecf144ca800d3f434f0764"},
-    {file = "lxml-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:d42e3a3fc18acc88b838efded0e6ec3edf3e328a58c68fbd36a7263a874906c8"},
-    {file = "lxml-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:eac68f96539b32fce2c9b47eb7c25bb2582bdaf1bbb360d25f564ee9e04c542b"},
-    {file = "lxml-5.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c26aab6ea9c54d3bed716b8851c8bfc40cb249b8e9880e250d1eddde9f709bf5"},
-    {file = "lxml-5.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cfbac9f6149174f76df7e08c2e28b19d74aed90cad60383ad8671d3af7d0502f"},
-    {file = "lxml-5.1.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:342e95bddec3a698ac24378d61996b3ee5ba9acfeb253986002ac53c9a5f6f84"},
-    {file = "lxml-5.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:725e171e0b99a66ec8605ac77fa12239dbe061482ac854d25720e2294652eeaa"},
-    {file = "lxml-5.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d184e0d5c918cff04cdde9dbdf9600e960161d773666958c9d7b565ccc60c45"},
-    {file = "lxml-5.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:98f3f020a2b736566c707c8e034945c02aa94e124c24f77ca097c446f81b01f1"},
-    {file = "lxml-5.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6d48fc57e7c1e3df57be5ae8614bab6d4e7b60f65c5457915c26892c41afc59e"},
-    {file = "lxml-5.1.0-cp38-cp38-win32.whl", hash = "sha256:7ec465e6549ed97e9f1e5ed51c657c9ede767bc1c11552f7f4d022c4df4a977a"},
-    {file = "lxml-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:b21b4031b53d25b0858d4e124f2f9131ffc1530431c6d1321805c90da78388d1"},
-    {file = "lxml-5.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6a2a2c724d97c1eb8cf966b16ca2915566a4904b9aad2ed9a09c748ffe14f969"},
-    {file = "lxml-5.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:843b9c835580d52828d8f69ea4302537337a21e6b4f1ec711a52241ba4a824f3"},
-    {file = "lxml-5.1.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b99f564659cfa704a2dd82d0684207b1aadf7d02d33e54845f9fc78e06b7581"},
-    {file = "lxml-5.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8b0c78e7aac24979ef09b7f50da871c2de2def043d468c4b41f512d831e912"},
-    {file = "lxml-5.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9bcf86dfc8ff3e992fed847c077bd875d9e0ba2fa25d859c3a0f0f76f07f0c8d"},
-    {file = "lxml-5.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:49a9b4af45e8b925e1cd6f3b15bbba2c81e7dba6dce170c677c9cda547411e14"},
-    {file = "lxml-5.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:280f3edf15c2a967d923bcfb1f8f15337ad36f93525828b40a0f9d6c2ad24890"},
-    {file = "lxml-5.1.0-cp39-cp39-win32.whl", hash = "sha256:ed7326563024b6e91fef6b6c7a1a2ff0a71b97793ac33dbbcf38f6005e51ff6e"},
-    {file = "lxml-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8d7b4beebb178e9183138f552238f7e6613162a42164233e2bda00cb3afac58f"},
-    {file = "lxml-5.1.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9bd0ae7cc2b85320abd5e0abad5ccee5564ed5f0cc90245d2f9a8ef330a8deae"},
-    {file = "lxml-5.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8c1d679df4361408b628f42b26a5d62bd3e9ba7f0c0e7969f925021554755aa"},
-    {file = "lxml-5.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2ad3a8ce9e8a767131061a22cd28fdffa3cd2dc193f399ff7b81777f3520e372"},
-    {file = "lxml-5.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:304128394c9c22b6569eba2a6d98392b56fbdfbad58f83ea702530be80d0f9df"},
-    {file = "lxml-5.1.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d74fcaf87132ffc0447b3c685a9f862ffb5b43e70ea6beec2fb8057d5d2a1fea"},
-    {file = "lxml-5.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8cf5877f7ed384dabfdcc37922c3191bf27e55b498fecece9fd5c2c7aaa34c33"},
-    {file = "lxml-5.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:877efb968c3d7eb2dad540b6cabf2f1d3c0fbf4b2d309a3c141f79c7e0061324"},
-    {file = "lxml-5.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f14a4fb1c1c402a22e6a341a24c1341b4a3def81b41cd354386dcb795f83897"},
-    {file = "lxml-5.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:25663d6e99659544ee8fe1b89b1a8c0aaa5e34b103fab124b17fa958c4a324a6"},
-    {file = "lxml-5.1.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8b9f19df998761babaa7f09e6bc169294eefafd6149aaa272081cbddc7ba4ca3"},
-    {file = "lxml-5.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e53d7e6a98b64fe54775d23a7c669763451340c3d44ad5e3a3b48a1efbdc96f"},
-    {file = "lxml-5.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c3cd1fc1dc7c376c54440aeaaa0dcc803d2126732ff5c6b68ccd619f2e64be4f"},
-    {file = "lxml-5.1.0.tar.gz", hash = "sha256:3eea6ed6e6c918e468e693c41ef07f3c3acc310b70ddd9cc72d9ef84bc9564ca"},
-]
-
-[package.extras]
-cssselect = ["cssselect (>=0.7)"]
-html5 = ["html5lib"]
-htmlsoup = ["BeautifulSoup4"]
-source = ["Cython (>=3.0.7)"]
 
 [[package]]
 name = "mako"
@@ -981,4 +878,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.0"
-content-hash = "17deb4971f2f6178c358e80d37fdeacab2b9a8b995e545ffc8288aa2f3087346"
+content-hash = "02b8ef1de6eb0a0727ce09a3ab902ccd278433c25ea1b5b53dbaaa2f3bc8c183"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vulpes"
-version = "1.0.1"
+version = "2.0.0"
 description = ""
 authors = ["June <june@peanut.one>"]
 readme = "README.md"
@@ -9,7 +9,6 @@ readme = "README.md"
 python = "^3.10.0"
 alembic = "^1.13.1"
 boto3 = "^1.33.7"
-feedgen = "^1.0.0"
 Flask = "^3.0.0"
 flask-sqlalchemy = "^3.1.1"
 requests = "^2.31.0"
@@ -27,13 +26,14 @@ exclude = ["nitre/"]
 [tool.ruff.lint]
 select = [  # Brought over whole-cloth from another project of mine.
     "E", "E501", "I", "D",
-    "N", "F", "UP",
+    "N", "F", "UP", "TD", "W",
     "BLE", "B", "COM", "C4",
     "DTZ", "RET", "SLF", "SIM",
 ]
 ignore = [
     "D100", "D104", "D107", "D203", "D213", "D400",
-    "S113"
+    "S113",
+    "TD003",
 ]
 
 [tool.ruff.isort]

--- a/vulpes/__init__.py
+++ b/vulpes/__init__.py
@@ -52,6 +52,7 @@ def create_app(test_config=None):
     app.register_blueprint(snapcast.bp)
     app.register_blueprint(twitch.bp)
 
+    # noinspection PyUnusedLocal
     @app.errorhandler(404)
     def fower_oh_fower(e):
         return render_template("fower-oh-fower.html"), 404

--- a/vulpes/blueprints/snapcast/jxml.py
+++ b/vulpes/blueprints/snapcast/jxml.py
@@ -1,0 +1,307 @@
+"""A very small podcast RSS generator. Currently in beta."""
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+from xml.etree import ElementTree as ETree
+
+
+class JXElement(ETree.Element):
+    """Base class for podcast types. Provides sub_element."""
+
+    dt_fmt = "%a, %d %b %Y %H:%M:%S %z"
+
+    def sub_elem(self, name, attrib=None, text=None):
+        """Add a sub-element to the current element and return it.
+
+        :param name: The tag name of the child.
+        :param attrib: A dict of attributes for the child.
+        :param text: The text for the child.
+        """
+        if attrib is None and text is None:
+            return None
+        if attrib is None:
+            attrib = {}
+        sub = ETree.SubElement(self, name, attrib=attrib)
+        if text is not None:
+            sub.text = str(text)
+        return sub
+
+
+# TODO(June): Give examples of what values are important.
+# https://github.com/ArrBianca/peanut/issues/22
+class FeedItem(JXElement):
+    """An ETree Element that represents an `item` tag in a podcast feed."""
+
+    tag = "item"
+
+    def __init__(self,
+                 title: str,
+                 media_url: str,
+                 media_size: int,
+                 media_type: str, **kwargs) -> None:
+        self.title: str = title
+        """The episode's title"""
+        self.subtitle: Optional[str] = None
+        """A short subtitle, usually shown, smaller, directly below the title."""
+        self.description: Optional[str] = None
+        """A longer description.
+
+         Accessable from an episode's info page. If a subtitle is not provided
+         but a description is, it is used to fill the space. If this is not
+         needed, set subtitle to empty explicitly.
+         """
+        self.uuid: Optional[str | UUID] = None
+        """The episode's UUID.
+
+        This is used to identify the episode and should not change. it is
+        HIGHLY recommended to set this value. If not supplied, the URL of the
+        item's enclosed media will be used instead.
+        """
+
+        self.media_url: Optional[str] = media_url
+        """URL of the media file."""
+        self.media_size: Optional[int] = media_size
+        """Size in bytes of the media file."""
+        self.media_type: Optional[str] = media_type
+        """MIME type of the media file.
+
+        Required, but iTunes ignores this value and uses only the media's file
+        extension.
+        """
+
+        self.media_duration: Optional[int | timedelta] = None
+        """Duration of the media file in seconds."""
+        self.pub_date: Optional[datetime] = None
+        """Publication date of the episode."""
+        self.link: Optional[str] = None
+        """URL of an episode-specific page, or any other URL.
+
+        Exposed to the user as a clickable button in some clients.
+        """
+        self.image: Optional[str] = None
+        """URL of the episode's cover art.
+
+        This should be a square jpg or png, and is infuriatingly ignored in
+        Apple Podcasts at the time of writing.
+        """
+
+        # Does nothing in my tests. Only works at podcast level.
+        # self.explicit: Optional[bool] = None
+        self.episode_type: Optional[str] = None
+        """String identifying the type of episode.
+
+        Either 'full', 'trailer', or 'bonus'.
+        """
+        self.season: Optional[str | int] = None
+        """The season number of the episode.
+
+        A serial show containing exactly one unnumbered season (season tag
+        ommitted) is often shown without an otherwise redundant season
+        selector in apps. Consider leaving this out if your podcast has
+        numbered episodes but only one season."""
+        self.episode: Optional[str | int] = None
+        """The episode number.
+
+        Used for sorting `serial` shows. The value is recorded and shown in
+        certain places for episodic shows but does not influence sorting.
+
+        Bonus episodes tied to a particular episode should be given episodeType
+        of `bonus` and the same episode number. Apple Podcasts shows this
+        correctly, Pocket Casts does not.
+
+        Bonus episodes attached to the show as a whole should not be numbered.
+        Ditto as above for correct portrayal.
+        """
+
+        self.itunes_block: bool = False
+        """Whether to withhold this episode from appearing in iTunes."""
+
+        for kwarg in kwargs:
+            setattr(self, kwarg, kwargs[kwarg])
+
+        super().__init__(self.tag, {})
+
+    def build(self):
+        """Construct and return a podcast-compatible <item> tag."""
+        # Check the mandatory attributes.
+        for name in ["title", "media_url", "media_size", "media_type"]:
+            if getattr(self, name) is None:
+                raise ValueError(f"{name} element is required.")
+
+        # TODO(June): Validate.
+        # https://github.com/ArrBianca/peanut/issues/21
+
+        # Required elements
+        self.sub_elem("title", text=self.title)
+        self.sub_elem("enclosure", attrib={
+            'url': self.media_url,
+            'length': str(self.media_size),
+            'type': self.media_type,
+        })
+
+        # Simple text fields
+        self.sub_elem("itunes:subtitle", text=self.subtitle)
+        self.sub_elem("description", text=self.description)
+        self.sub_elem("link", text=self.link)
+        # TODO(June): Restrict episodeType values
+        # https://github.com/ArrBianca/peanut/issues/23
+        self.sub_elem("itunes:episodeType", text=self.episode_type)
+        self.sub_elem("itunes:season", text=self.season)
+        self.sub_elem("itunes:episode", text=self.episode)
+
+        if self.image is not None:
+            self.sub_elem("itunes:image", {'href': self.image})
+        # self.sub_element("itunes:explicit", text='yes' if self.explicit else 'no')
+
+        # Some troublemakers
+        if md := self.media_duration is not None:
+            if isinstance(md, timedelta):
+                md = int(self.media_duration.total_seconds())
+            self.sub_elem("itunes:duration", text=md)
+
+        if self.uuid is None:
+            self.uuid = self.media_url
+        self.sub_elem("guid", {'isPermaLink': "false"}, text=str(self.uuid))
+
+        if (pd := self.pub_date) is not None:
+            if pd.tzinfo is None or pd.tzinfo.utcoffset(pd) is None:
+                pd = pd.replace(tzinfo=timezone.utc)
+            self.sub_elem("pubDate", text=pd.strftime(self.dt_fmt))
+
+        return self
+
+
+class PodcastFeed(JXElement):
+    """An ETree Element that represents the `channel` tag in a podcast feed."""
+
+    tag = "channel"
+    _categories = []
+
+    generator: str = "JXML - The J stands for June!"
+    """Indentifier for the feed-generating library."""
+
+    def __init__(self, title: str, description: str,
+                 image: str, explicit: bool, **kwargs) -> None:
+        self.episodes: list[FeedItem] = []
+
+        # "Required" elements
+        self.title = title
+        self.description = description
+        self.image = image
+        """URL pointing to a png or jpg cover image for the podcast feed."""
+        self.explicit = explicit
+
+        # Optional
+        self.categories = []
+        """Category list for the podcast.
+
+        Should be of the form of either:
+            - A list of objects with <cat> and [sub] attrs.
+            - A list of dicts with <cat> and [sub] keys.
+        (`cat` is mandatory if given, `sub` is optional)
+
+        The values of `cat` and `sub` should correspond to the categories and
+        subcategories laid out in the Apple Podcasts documentation at
+        podcasters.apple.com/support/1691-apple-podcasts-categories`   .
+        Pay attention to the rules specified there for string escaping.
+        """
+
+        self.author: Optional[str] = None
+        """The person or group responsible for creating the show."""
+        self.feed_url: Optional[str] = None
+        """Self-referencing URL of the feed itself, if known."""
+        self.link: Optional[str] = None
+        """URL pointing to the website for the podcast."""
+        self.copyright: Optional[str] = None
+        """A human-readable copyright string."""
+        self.language: Optional[str] = None
+        """ISO639 two-letter language code."""
+
+        self.last_build_date: Optional[datetime] = None
+        """The last time that feed content changed.
+
+        Set this value to current when adding or updating an item or any field
+        of the podcast.
+        """
+        self.itunes_block: Optional[bool] = False
+        """Prevent this podcast from appearing in the iTunes directory."""
+
+        for kwarg in kwargs:
+            setattr(self, kwarg, kwargs[kwarg])
+
+        super().__init__("channel", {})
+
+    def build(self, pretty=False) -> str:
+        """Construct a podcast RSS feed."""
+        root = ETree.Element("rss", {
+            'version': "2.0",
+            'xmlns:itunes': "http://www.itunes.com/dtds/podcast-1.0.dtd",
+            'xmlns:atom': "http://www.w3.org/2005/Atom",
+        })
+        root.append(self)
+
+        for name in ["title", "description", "image", "explicit"]:
+            if getattr(self, name) is None:
+                raise ValueError(f"{name} element is required.")
+
+        # Validate link types
+        for name in ['image', 'link', 'feed_url']:
+            value = getattr(self, name, None)
+            if value is not None and not value.startswith('http'):
+                raise ValueError("Links should start with http:// or https://")
+
+        self.sub_elem("title", text=self.title)
+        # Maybe this could stand to be duplicated to itunes:summary?
+        self.sub_elem("description", text=self.description)
+        if self.image:
+            self.sub_elem("itunes:image", {'href': self.image})
+        # Okay so the itunes podcast docs straight up lie. It says explicit
+        # should be true or false, but it only accepts yes and no. How dare.
+        self.sub_elem("itunes:explicit", text='yes' if self.explicit else 'no')
+
+        # Then the simple text-only elems:
+        self.sub_elem("itunes:author", text=self.author)
+        self.sub_elem("copyright", text=self.copyright)
+        self.sub_elem("link", text=self.link)
+        self.sub_elem("language", text=self.language)
+        self.sub_elem("itunes:block", text="yes" if self.itunes_block else None)
+
+        # Category processing.
+        # TODO(June): clean this up lol.
+        for category in self.categories:
+            try:
+                cat = self.sub_elem("itunes:category", {'text': category.cat})
+                if cat is not None and hasattr(category, 'sub') and category.sub is not None:
+                    ETree.SubElement(cat, "itunes:category", {'text': category.sub})
+            except AttributeError:
+                cat = self.sub_elem("itunes:category", {'text': category['cat']})
+                if cat is not None and 'sub' in category and category['sub'] is not None:
+                    ETree.SubElement(cat, "itunes:category", {'text': category.sub})
+
+        # Now relevant RSS elements brought forward:
+        if (lbd := self.last_build_date) is None:
+            lbd = datetime.now(timezone.utc)
+
+        if (lbd.tzinfo is None or
+                lbd.tzinfo.utcoffset(lbd) is None):
+            lbd = lbd.replace(tzinfo=timezone.utc)
+        self.last_build_date = lbd
+
+        self.sub_elem("lastBuildDate", text=self.last_build_date.strftime(self.dt_fmt))
+        self.sub_elem("generator", text=self.generator)
+
+        # Atom self-link
+        if self.feed_url is not None:
+            self.sub_elem("atom:link", {
+                'href': self.feed_url,
+                'rel': 'self',
+                'type': 'application/rss+xml',
+            })
+
+        # Episode time!
+        for episode in self.episodes:
+            self.append(episode.build())
+
+        if pretty:
+            ETree.indent(root)
+        return ETree.tostring(root, encoding='unicode', xml_declaration=True) + '\n'

--- a/vulpes/blueprints/snapcast/models.py
+++ b/vulpes/blueprints/snapcast/models.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import List, Literal, Optional
 from uuid import UUID
 
-from sqlalchemy import CheckConstraint, ForeignKey
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from vulpes.blueprints.snapcast.jxml import FeedItem, PodcastFeed
 
 from ... import db
 
@@ -33,35 +35,34 @@ class DatetimeFormattingModel:
         return d
 
 
-class Podcast(DatetimeFormattingModel, db.Model):
+class Podcast(DatetimeFormattingModel, db.Model, PodcastFeed):
     """ORM Mapping for the database's `podcast` table."""
 
     __tablename__ = 'podcast'
 
     id: Mapped[int] = mapped_column(primary_key=True)
     uuid: Mapped[UUID]
-    name: Mapped[str]
-    website: Mapped[str]
+    title: Mapped[str]
+    link: Mapped[str]
     description: Mapped[str]
     explicit: Mapped[bool]
     image: Mapped[str]
-    author_name: Mapped[str]
+    author: Mapped[str]
     copyright: Mapped[Optional[str]]
     language: Mapped[str] = mapped_column(default="en-US")
     feed_url: Mapped[Optional[str]]
     categories: Mapped[List["Category"]] = relationship()
-    withhold_from_itunes: Mapped[bool] = mapped_column(default=False)
+    itunes_block: Mapped[bool] = mapped_column(default=False)
+    new_feed_url: Mapped[Optional[str]]
+    complete: Mapped[bool] = mapped_column(default=False)
     auth_token: Mapped[UUID]
-    last_modified: Mapped[Optional[datetime]]
-    is_serial: Mapped[Optional[bool]]
-    episodes: Mapped[List["Episode"]] = relationship(back_populates="podcast")
-
-    def __init__(self, **kwargs):
-        for attr, value in kwargs.items():
-            setattr(self, attr, value)
+    last_build_date: Mapped[Optional[datetime]]
+    is_serial: Mapped[bool] = mapped_column(default=False)
+    episodes: Mapped[List["Episode"]] = relationship(
+        back_populates="podcast", order_by="Episode.pub_date")
 
 
-class Episode(DatetimeFormattingModel, db.Model):
+class Episode(FeedItem, DatetimeFormattingModel, db.Model):
     """ORM Mapping for the database's `episode` table."""
 
     __tablename__ = 'episode'
@@ -70,29 +71,27 @@ class Episode(DatetimeFormattingModel, db.Model):
     uuid: Mapped[UUID]
     podcast_uuid = mapped_column(ForeignKey(Podcast.uuid))
     podcast: Mapped["Podcast"] = relationship(back_populates="episodes")
-    title: Mapped[Optional[str]]
-    summary: Mapped[Optional[str]]
+    title: Mapped[str]
     subtitle: Mapped[Optional[str]]
-    long_summary: Mapped[Optional[str]]
+    description: Mapped[Optional[str]]
     media_url: Mapped[str]
     media_size: Mapped[int]
     media_type: Mapped[str]
     media_duration: Mapped[Optional[timedelta]]
     pub_date: Mapped[datetime]
     link: Mapped[Optional[str]]
-    episode_art: Mapped[Optional[str]]
+    image: Mapped[Optional[str]]
+    episode_type: Mapped[Literal["full", "trailer", "bonus"]] = mapped_column(default='full')
+    season: Mapped[Optional[int]]
+    episode: Mapped[Optional[int]]
 
     def __init__(self, **kwargs):
         for attr, value in kwargs.items():
             setattr(self, attr, value)
-
-    __table_args__ = (
-        CheckConstraint('title IS NOT NULL OR summary IS NOT NULL',
-                        name='title_summary_check'),
-    )
+        super().__init__()
 
 
-class Category(db.Model):
+class Category(DatetimeFormattingModel, db.Model):
     """ORM Mapping for the database's `category` table."""
 
     __tablename__ = 'category'
@@ -101,3 +100,7 @@ class Category(db.Model):
     podcast_id: Mapped[int] = mapped_column(ForeignKey("podcast.id"))
     cat: Mapped[str]
     sub: Mapped[Optional[str]]
+
+    # def __init__(self):
+    #     self.__dict__['cat'] = self.cat
+    #     self.__dict__['sub'] = self.sub

--- a/vulpes/blueprints/snapcast/util.py
+++ b/vulpes/blueprints/snapcast/util.py
@@ -32,5 +32,5 @@ def touch_podcast(podcast_uuid):
     db.session.execute(
         update(Podcast)
         .where(Podcast.uuid == podcast_uuid)
-        .values({Podcast.last_modified: datetime.now(timezone.utc)}),
+        .values({Podcast.last_build_date: datetime.now(timezone.utc)}),
     )

--- a/vulpes/blueprints/snapcast/views.py
+++ b/vulpes/blueprints/snapcast/views.py
@@ -129,8 +129,6 @@ def get_episode(podcast_uuid: UUID, episode_id: str):
             .where(Episode.uuid == UUID(episode_id)),
         )
 
-    if result is None:
-        return abort(404)
     return jsonify(result.as_dict())
 
 

--- a/vulpes/blueprints/snapcast/views.py
+++ b/vulpes/blueprints/snapcast/views.py
@@ -163,11 +163,12 @@ def delete_episode(podcast_uuid: UUID, episode_uuid: UUID):
         .where(Episode.uuid == episode_uuid)
         .where(Episode.podcast_uuid == podcast_uuid),
     )
-    touch_podcast(podcast_uuid)
-    db.session.commit()
 
     if result.rowcount == 0:
         return abort(404)
+    touch_podcast(podcast_uuid)
+    db.session.commit()
+
     return jsonify(success=True)
 
 

--- a/vulpes/blueprints/snapcast/views.py
+++ b/vulpes/blueprints/snapcast/views.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
-from feedgen.feed import FeedGenerator
 from flask import Blueprint, Response, abort, jsonify, request
 from sqlalchemy import delete, select, update
+from sqlalchemy.orm import joinedload
 
 from .models import Episode, Podcast
 from .util import authorization_required, touch_podcast
@@ -12,63 +12,26 @@ from ... import db
 bp = Blueprint('snapcast', __name__, url_prefix='/snapcast')
 
 
-# noinspection PyUnresolvedReferences
 @bp.route("/<uuid:podcast_uuid>/feed.xml", methods=["GET"])
 def generate_feed(podcast_uuid: UUID):
     """Pull podcast and episode data from the db and generate a podcast xml file."""
+    # noinspection PyTypeChecker
     cast: Podcast = db.first_or_404(
         select(Podcast)
-        .where(Podcast.uuid == podcast_uuid),
+        .where(Podcast.uuid == podcast_uuid)
+        .options(joinedload('*')),
     )
 
     # The caveat to sqlalchemy and sqlite: It stores datetimes as naive.
-    last_modified: datetime = cast.last_modified.replace(tzinfo=timezone.utc)
+    cast.last_build_date = cast.last_build_date.replace(tzinfo=timezone.utc)
     # The database column stores microseconds which aren't included in the
     # request. If they're just about equal we don't update anything.
     if ((request.if_modified_since is not None) and
-       (last_modified - request.if_modified_since).total_seconds() < 1):
+       (cast.last_build_date - request.if_modified_since).total_seconds() < 1):
         return Response(status=304)
 
-    p = FeedGenerator()
-    p.load_extension('podcast')
-
-    p.title(cast.name)
-    p.description(cast.description)
-    p.link(href=cast.website)
-    for category in cast.categories:
-        p.podcast.itunes_category({
-            'cat': category.cat,
-            'sub': category.sub,
-        })
-    p.language(cast.language)
-    p.podcast.itunes_image(cast.image)
-    # p.author({'name': cast.author_name})
-    p.podcast.itunes_author(cast.author_name)
-    p.podcast.itunes_block(cast.withhold_from_itunes)
-    p.podcast.itunes_explicit('yes' if cast.explicit else 'no')
-    p.lastBuildDate(last_modified)
-
-    for episode in cast.episodes:
-        episode: Episode = episode
-        e = p.add_item()
-
-        e.id(str(episode.uuid))
-        e.title(episode.title)
-        e.podcast.itunes_subtitle(episode.subtitle)
-        e.description(episode.long_summary)
-        e.enclosure(
-            episode.media_url,
-            episode.media_size,
-            episode.media_type,
-        )
-        if episode.media_duration:
-            e.podcast.itunes_duration(int(episode.media_duration.total_seconds()))
-        e.pubDate(episode.pub_date.replace(tzinfo=timezone.utc))
-        e.link(href=episode.link)
-        e.podcast.itunes_image(episode.episode_art)
-
-    response = Response(p.rss_str(pretty=True), mimetype='text/xml')
-    response.last_modified = last_modified
+    response = Response(cast.build(), mimetype='text/xml')
+    response.last_modified = cast.last_build_date
     return response
 
 
@@ -79,7 +42,7 @@ def feed_head(podcast_uuid: UUID):
     Fill `Last-Modified` to save on data transfer.
     """
     last_modified: Podcast = db.one_or_404(
-        select(Podcast.last_modified)
+        select(Podcast.last_build_date)
         .where(Podcast.uuid == podcast_uuid),
     )
     response = Response()

--- a/vulpes/blueprints/snapcast/views.py
+++ b/vulpes/blueprints/snapcast/views.py
@@ -22,10 +22,10 @@ def generate_feed(podcast_uuid: UUID):
         .options(joinedload('*')),
     )
 
-    # The caveat to sqlalchemy and sqlite: It stores datetimes as naive.
+    # The caveat to sqlite: It stores datetimes as naive.
     cast.last_build_date = cast.last_build_date.replace(tzinfo=timezone.utc)
-    # The database column stores microseconds which aren't included in the
-    # request. If they're just about equal we don't update anything.
+    # The database column also stores microseconds which aren't included in
+    # the request. If they're just about equal we don't update anything.
     if ((request.if_modified_since is not None) and
        (cast.last_build_date - request.if_modified_since).total_seconds() < 1):
         return Response(status=304)


### PR DESCRIPTION
* Rework the database schema to match the tables more closely to the layout of the target XML structure.
    * Learned a lot about migration.
    * If I'd spent an extra hour designing the database months ago I'd have saved three today.
* Write my own Podcast RSS XML feed generator, `jxml` (the J stands for June) 
    * It's quite small and doesn't validate the input very strongly at all.
    * The layout of attributes is very close to the target XML structure as well, and thus matches with the db.
    * I subclass it right in the ORM class and call `.build()` directly on the SELECT result set.
        * Demonic power.
    * The `generate_feed` view is so slim now.
* gosh I hope this all works lmao. What if I had tests that'd be nice. 
* Bump major version as the schema changes break my tool scripts.

This PR fixes #14 as well!